### PR TITLE
Implements the initial workflow

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -144,7 +144,7 @@ jobs:
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
           replicated-app: "slackernews"
-          replicated-api-token: ${{ secrets.REPLICATED_APP_TOKEN }}
+          replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots
           promote-channel: "Unstable"

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -21,6 +21,10 @@ on:
         description: Replicated App Slug
         required: true
         type: string
+      version:
+        description: Release Version
+        required: true
+        type: string
       proxy:
         description: Proxy Image Registry
         required: true
@@ -59,7 +63,7 @@ jobs:
           tags: |
                 type=sha,format=long
                 type=schedule
-                type=semver,pattern={{version}}
+                type=raw,${{ inputs.version }}
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
@@ -94,9 +98,6 @@ jobs:
 
       - run: make chart
 
-      - id: get_version
-        uses: battila7/get-version-action@v2
-
       - uses: azure/setup-helm@v1
         with:
           version: "3.9.0"
@@ -114,7 +115,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ inputs.namespace }}/slackernews-web:${{ steps.get_version.outputs.version-without-v }}'
+          replace: 'proxy/${{ inputs.slug }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - id: package-helm-chart
@@ -123,20 +124,20 @@ jobs:
           helm dep up --debug && \
           cd .. && \
           helm package \
-            --app-version=${{ steps.get_version.outputs.version-without-v }} \
-            --version=${{ steps.get_version.outputs.version-without-v }} \
+            --app-version=${{ inputs.version }} \
+            --version=${{ inputs.version }} \
             ./slackernews
 
 
       - name: Copy the helm chart to the kots directory
-        run: cp ./chart/slackernews-${{ steps.get_version.outputs.version-without-v }}.tgz ./kots
+        run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
 
       - name: Update the HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'kots/slackernews-chart.yaml'
           find: '$VERSION'
-          replace: '${{ steps.get_version.outputs.version-without-v }}'
+          replace: '${{ inputs.version }}'
           regex: false
 
       - name: Create the unstable release
@@ -147,4 +148,4 @@ jobs:
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots
           promote-channel: "Unstable"
-          version: ${{ steps.get_version.outputs.version-without-v }}
+          version: ${{ inputs.version }}

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -132,6 +132,14 @@ jobs:
       - name: Copy the helm chart to the kots directory
         run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
 
+      - name: Update the slackernews-chart.yaml with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'kots/slackernews-chart.yaml'
+          find: '$IMAGE'
+          replace: 'proxy/${{ inputs.slug }}/${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          regex: false
+
       - name: Update the HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -16,7 +16,7 @@ on:
       namespace:
         description: Registry Namespace
         required: true
-        default: ${{ github.actor }}/slackernews
+        default: '${{ github.actor }}/slackernews'
         type: string
       slug:
         description: Replicated App Slug

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: slackernews/slackernews.git
           ref: ${{ inputs.branch }}
-          token: ${{ github.token }} 
+          token: ${{ secrets.GITHUB_TOKEN }} 
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -47,7 +47,7 @@ jobs:
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image
         id: web-meta
@@ -84,6 +84,10 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: slackernews/slackernews.git
+          ref: ${{ inputs.branch }}
+          token: ${{ github.token }} 
 
       - run: make chart
 

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ github.token }}
 
       - name: Extract metadata (tags, labels) for web image
         id: web-meta

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -22,10 +22,6 @@ on:
         description: Replicated App Slug
         required: true
         type: string
-      token:
-        description: Replicated API Token
-        required: true
-        type: string
       proxy:
         description: Proxy Image Registry
         required: true
@@ -140,7 +136,7 @@ jobs:
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
           replicated-app: "slackernews"
-          replicated-api-token: ${{ input.token }}
+          replicated-api-token: ${{ secrets.REPLICATED_APP_TOKEN }}
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots
           promote-channel: "Unstable"

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: slackernews/slackernews.git
-          token: ${{ secrets.GH_PAT }} # `GH_PAT` is a secret that contains your PAT
+          token: ${{ github.token }} # `GH_PAT` is a secret that contains your PAT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
-          replicated-app: "slackernews"
+          replicated-app: ${{ inputs.slug }}
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -36,7 +36,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: slackernews/slackernews.git
-          token: ${{ github.token }} # `GH_PAT` is a secret that contains your PAT
+          branch: ${{ inputs.branch }}
+          token: ${{ github.token }} 
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -8,11 +8,6 @@ on:
         required: true
         default: main
         type: string
-      registry:
-        description: Private Image Registry
-        required: true
-        default: ghcr.io
-        type: string
       namespace:
         description: Registry Namespace
         required: true
@@ -30,6 +25,9 @@ on:
         required: true
         default: proxy.replicated.com
         type: string
+
+env:
+  REGISTRY: ghcr.io
 
 jobs:
   build:
@@ -52,7 +50,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ inputs.registry }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -67,7 +65,7 @@ jobs:
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web
+          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
 
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
@@ -115,7 +113,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: 'proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - id: package-helm-chart
@@ -137,7 +135,7 @@ jobs:
         with:
           include: 'kots/slackernews-chart.yaml'
           find: '$IMAGE'
-          replace: '${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: '${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - name: Update the HelmChart kind

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -16,7 +16,6 @@ on:
       namespace:
         description: Registry Namespace
         required: true
-        default: '${{ github.actor }}/slackernews'
         type: string
       slug:
         description: Replicated App Slug

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -115,7 +115,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: 'proxy/${{ inputs.slug }}/${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - id: package-helm-chart

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: slackernews/slackernews.git
-          branch: ${{ inputs.branch }}
+          ref: ${{ inputs.branch }}
           token: ${{ github.token }} 
 
       - name: Set up Docker Buildx

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -137,7 +137,7 @@ jobs:
         with:
           include: 'kots/slackernews-chart.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: '${{ inputs.registry }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - name: Update the HelmChart kind

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -30,6 +30,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     outputs:
       tags: ${{ steps.web-meta.outputs.tags }}
     steps:


### PR DESCRIPTION
TL;DR
-----

Fleshes out a manually run workflow for creating a demo

Details
-------

Provides a complete implementation of a workflow run using the GitHub workflow dispatch option. The workflow is used to build SlackerNews and release it to a GitHub account/org and Replicated vendor team other than the main Slackernews ones.

To use it, run the action from the "Actions" tab and specify the following:

1. The branch on the Slackernews repo you want to build from
2. The namespace on the `ghcr.io` registry to push images to.
3. Your application slug
4. The version for your release to `Unstable`
5. The domain to use for the proxy image registry

The workflow is the same as the release workflow for Slackernews. In the end you'll have an images pushed to your own namespace on the GitHub registry and a release promoted to the `Unstable` channel in your own vendor tea. That team will pull images through the proxy using the domain you specify.
