### PR TITLE
Signs the Slackernews Image

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Sign the web image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ steps.build-push.outputs.digest }} --force
+        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ steps.build-push.outputs.digest }} --yes
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -98,6 +98,13 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Sign the private web image
         env:
           COSIGN_EXPERIMENTAL: "true"

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     outputs:
       tags: ${{ steps.web-meta.outputs.tags }}
     steps:
@@ -43,6 +44,9 @@ jobs:
           repository: slackernews/slackernews.git
           ref: ${{ inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }} 
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -73,6 +77,7 @@ jobs:
           image: ghcr.io/${{ github.repository }}/cache
 
       - name: Build web image
+        id: build-push
         uses: docker/build-push-action@v4
         with:
           context: ./slackernews
@@ -82,6 +87,11 @@ jobs:
           push: true
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
+
+      - name: Sign the web image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ steps.build-push.outputs.digest }} --force
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -94,6 +94,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    outputs:
+      signature: ${{ steps.sign-web.outputs.signature }}
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0
@@ -106,7 +108,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign the web image
-        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
+        id: sign-web
+        run: |
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }})" >> $GITHUB_OUTPUT
 
   release:
     runs-on: ubuntu-22.04
@@ -155,7 +160,7 @@ jobs:
       - name: Copy the helm chart to the kots directory
         run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
 
-      - name: Update the slackernews-chart.yaml with the image path
+      - name: Set web image in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'kots/slackernews-chart.yaml'
@@ -163,13 +168,18 @@ jobs:
           replace: '${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
-      - name: Update the HelmChart kind
+      - name: Update chart version in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'kots/slackernews-chart.yaml'
           find: '$VERSION'
           replace: '${{ inputs.version }}'
           regex: false
+
+      - name: Add image signature to airgap bundle
+        uses: mikefarah/yq@v4.40.5
+        with:
+          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.signature }}" ]' kots/replicated-app.yaml
 
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -105,18 +105,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sign the private web image
-        env:
-          COSIGN_EXPERIMENTAL: "true"
+      - name: Sign the web image
         run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
-
-      - name: Sign the proxy web image
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
-            --sign-container-identity ${{ inputs.proxy }}/proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
-            --yes
 
   release:
     runs-on: ubuntu-22.04
@@ -131,7 +121,7 @@ jobs:
 
       - run: make chart
 
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
         with:
           version: "3.9.0"
         id: install

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -108,7 +108,7 @@ jobs:
           COSIGN_EXPERIMENTAL: "true"
         run: |
           cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
-            --sign-container-identity ${{ inputs.proxy }}/proxy/${{ inputs.slug }}/${{ ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
+            --sign-container-identity ${{ inputs.proxy }}/proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
             --yes
 
   release:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -38,15 +38,13 @@ jobs:
       id-token: write
     outputs:
       tags: ${{ steps.web-meta.outputs.tags }}
+      digest: ${{ steps.build-push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
           repository: slackernews/slackernews.git
           ref: ${{ inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }} 
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -88,15 +86,35 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Sign the web image
+  sign:
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.3.0
+
+      - name: Sign the private web image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ steps.build-push.outputs.digest }} --yes
+        run: cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
+
+      - name: Sign the proxy web image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
+            --sign-container-identity ${{ inputs.proxy }}/proxy/${{ inputs.slug }}/${{ ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} \
+            --yes
 
   release:
     runs-on: ubuntu-22.04
     needs:
-      - build
+      - sign
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
TL;DR
-----

Updates demo workflow with image singatures

Details
-------

Uses the "keyless" method for cosign to sign the Slackernews web image. This approach records the signature to the public Rekor transparency log and updates the KOTS release so that airgap installs can still be validated.

