### PR TITLE
Provides images and signatures to airgap builder

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -251,13 +251,13 @@ jobs:
         id: airgap-web-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq -i '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' kots/slackernews-chart.yaml
 
       - name: Provide nginx image to the airgap builder
         id: airgap-nginx-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq -i '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' kots/slackernews-chart.yaml
 
       - name: Add image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -247,6 +247,18 @@ jobs:
           replace: '${{ inputs.namespace }}'
           regex: false
 
+      - name: Provide web image to the airgap builder
+        id: airgap-web-image
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namesace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+
+      - name: Provide nginx image to the airgap builder
+        id: airgap-web-image
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namesace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+
       - name: Add image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5
         with:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -139,13 +139,13 @@ jobs:
       - name: Sign the web image
         id: sign-web
         run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 
       - name: Sign the NGINX image
         id: sign-nginx
         run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.digest }} --yes
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.nginx-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.nginx-digest }})" >> $GITHUB_OUTPUT
 
   release:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -103,9 +103,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx
           tags: ${{ steps.nginx-meta.outputs.tags }}
-          labels: ${{ steps.nginxweb-meta.outputs.labels }}
+          labels: ${{ steps.nginx-meta.outputs.labels }}
           file: ./deploy/Dockerfile.nginx
           push: true
           cache-from: ${{ steps.cache.outputs.cache-from }}

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -254,7 +254,7 @@ jobs:
           cmd: yq '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
 
       - name: Provide nginx image to the airgap builder
-        id: airgap-web-image
+        id: airgap-nginx-image
         uses: mikefarah/yq@master
         with:
           cmd: yq '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -69,7 +69,7 @@ jobs:
                 type=ref,event=pr
           images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
 
-      - name: Extract metadata (tags, labels) for web image
+      - name: Extract metadata (tags, labels) for nginx image
         id: nginx-meta
         uses: docker/metadata-action@v5
         with:
@@ -88,7 +88,7 @@ jobs:
           image: ghcr.io/${{ github.repository }}/cache
 
       - name: Build web image
-        id: build-push
+        id: build-web
         uses: docker/build-push-action@v5
         with:
           context: ./slackernews
@@ -100,6 +100,7 @@ jobs:
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
       - name: Build nginx image
+        id: build-nginx
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -251,13 +251,13 @@ jobs:
         id: airgap-web-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' kots/slackernews-chart.yaml
+          cmd: yq -i '.spec.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' kots/slackernews-chart.yaml
 
       - name: Provide nginx image to the airgap builder
         id: airgap-nginx-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' kots/slackernews-chart.yaml
+          cmd: yq -i '.spec.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' kots/slackernews-chart.yaml
 
       - name: Add image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -121,7 +121,8 @@ jobs:
       packages: write
       id-token: write
     outputs:
-      signature: ${{ steps.sign-web.outputs.signature }}
+      web-signature: ${{ steps.sign-web.outputs.signature }}
+      nginx-signature: ${{ steps.sign-nginx.outputs.signature }}
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0
@@ -138,6 +139,12 @@ jobs:
         run: |
           cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }})" >> $GITHUB_OUTPUT
+
+      - name: Sign the NGINX image
+        id: sign-nginx
+        run: |
+          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.digest }})" >> $GITHUB_OUTPUT
 
   release:
     runs-on: ubuntu-22.04
@@ -259,10 +266,15 @@ jobs:
         with:
           cmd: yq -i '.spec.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' kots/slackernews-chart.yaml
 
-      - name: Add image signature to airgap bundle
+      - name: Add web image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5
         with:
-          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.signature }}" ]' kots/replicated-app.yaml
+          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.web-signature }}" ]' kots/replicated-app.yaml
+
+      - name: Add nginx image signature to airgap bundle
+        uses: mikefarah/yq@v4.40.5
+        with:
+          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.nginx-signature }}" ]' kots/replicated-app.yaml
 
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -251,13 +251,13 @@ jobs:
         id: airgap-web-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namesace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
 
       - name: Provide nginx image to the airgap builder
         id: airgap-web-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namesace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
 
       - name: Add image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -251,13 +251,13 @@ jobs:
         id: airgap-web-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq -i '.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
 
       - name: Provide nginx image to the airgap builder
         id: airgap-nginx-image
         uses: mikefarah/yq@master
         with:
-          cmd: yq '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
+          cmd: yq -i '.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' 'kots/slackernews-chart.yml'
 
       - name: Add image signature to airgap bundle
         uses: mikefarah/yq@v4.40.5

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -37,8 +37,10 @@ jobs:
       packages: write
       id-token: write
     outputs:
-      tags: ${{ steps.web-meta.outputs.tags }}
-      digest: ${{ steps.build-push.outputs.digest }}
+      web-tags: ${{ steps.web-meta.outputs.tags }}
+      web-digest: ${{ steps.build-web.outputs.digest }}
+      nginx-tags: ${{ steps.nginx-meta.outputs.tags }}
+      nginx-digest: ${{ steps.build-nginx.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -138,13 +140,13 @@ jobs:
         id: sign-web
         run: |
           cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.digest }})" >> $GITHUB_OUTPUT
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 
       - name: Sign the NGINX image
         id: sign-nginx
         run: |
           cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.digest }})" >> $GITHUB_OUTPUT
+          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.nginx-digest }})" >> $GITHUB_OUTPUT
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -104,8 +104,8 @@ jobs:
         with:
           context: .
           images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx
-          tags: ${{ steps.web-meta.outputs.tags }}
-          labels: ${{ steps.web-meta.outputs.labels }}
+          tags: ${{ steps.nginx-meta.outputs.tags }}
+          labels: ${{ steps.nginxweb-meta.outputs.labels }}
           file: ./deploy/Dockerfile.nginx
           push: true
           cache-from: ${{ steps.cache.outputs.cache-from }}


### PR DESCRIPTION
TL;DR
-----

Makes sure the airgap builder has the images and signatures

Details
-------

The Replicated Platform airgap buuilder cannot pull images through it's own proxy registry. This creates a challenge for Helm charts like Slackernews that reference the proxy in their default values. This change uses the `builder`
configuration to make sure those images end up in the bundle. It also adds the signatures into the bundle.
