### PR TITLE
Stops building unused NGINX image

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -213,12 +213,6 @@ jobs:
           replace: '${{ inputs.namespace }}'
           regex: false
 
-      - name: Provide web image to the airgap builder
-        id: airgap-web-image
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq -i '.spec.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' kots/slackernews-chart.yaml
-
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -39,8 +39,6 @@ jobs:
     outputs:
       web-tags: ${{ steps.web-meta.outputs.tags }}
       web-digest: ${{ steps.build-web.outputs.digest }}
-      nginx-tags: ${{ steps.nginx-meta.outputs.tags }}
-      nginx-digest: ${{ steps.build-nginx.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -71,19 +69,6 @@ jobs:
                 type=ref,event=pr
           images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
 
-      - name: Extract metadata (tags, labels) for nginx image
-        id: nginx-meta
-        uses: docker/metadata-action@v5
-        with:
-          tags: |
-                type=sha,format=long
-                type=schedule
-                type=raw,${{ inputs.version }}
-                type=ref,event=branch
-                type=ref,event=tag
-                type=ref,event=pr
-          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx
-
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
         with:
@@ -101,19 +86,6 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Build nginx image
-        id: build-nginx
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          tags: ${{ steps.nginx-meta.outputs.tags }}
-          labels: ${{ steps.nginx-meta.outputs.labels }}
-          file: ./deploy/Dockerfile.nginx
-          push: true
-          cache-from: ${{ steps.cache.outputs.cache-from }}
-          cache-to: ${{ steps.cache.outputs.cache-to }}
-
-
   sign:
     runs-on: ubuntu-22.04
     needs:
@@ -124,7 +96,6 @@ jobs:
       id-token: write
     outputs:
       web-signature: ${{ steps.sign-web.outputs.signature }}
-      nginx-signature: ${{ steps.sign-nginx.outputs.signature }}
     steps:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.3.0
@@ -141,12 +112,6 @@ jobs:
         run: |
           cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
-
-      - name: Sign the NGINX image
-        id: sign-nginx
-        run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.nginx-digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx@${{ needs.build.outputs.nginx-digest }})" >> $GITHUB_OUTPUT
 
   release:
     runs-on: ubuntu-22.04
@@ -187,14 +152,6 @@ jobs:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
           replace: 'proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
-          regex: false
-
-      - name: Update the values.yaml with the image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$NGINX_IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}'
           regex: false
 
       - id: package-helm-chart
@@ -261,22 +218,6 @@ jobs:
         uses: mikefarah/yq@master
         with:
           cmd: yq -i '.spec.builder.images.slackernews.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}"' kots/slackernews-chart.yaml
-
-      - name: Provide nginx image to the airgap builder
-        id: airgap-nginx-image
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq -i '.spec.builder.images.nginx.repository = "ghcr.io/${{ inputs.namespace }}/slackernews-nginx:${{ inputs.version }}"' kots/slackernews-chart.yaml
-
-      - name: Add web image signature to airgap bundle
-        uses: mikefarah/yq@v4.40.5
-        with:
-          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.web-signature }}" ]' kots/replicated-app.yaml
-
-      - name: Add nginx image signature to airgap bundle
-        uses: mikefarah/yq@v4.40.5
-        with:
-          cmd: yq -i '.spec.additionalImages += [ "${{ needs.sign.outputs.nginx-signature }}" ]' kots/replicated-app.yaml
 
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint


### PR DESCRIPTION
TL;DR
-----

Removes workflow steps related to NGINX image

Details
-------

Cleans up the workflow so it no longer does anything with the NGINX
image that hasn't been used for a long time. The chart stopped using the
imagea while ago and I updated the upstream to account for that last
week.