### PR TITLE
Adapts for SecureBuild

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,8 @@ on:
         type: string
 
 env:
-  REGISTRY: ghcr.io
+  SLACKERNEWS_REGISTRY: ghcr.io
+  SECURE_BUILD_REGISTRY: ghcr.io
 
 jobs:
   build:
@@ -52,9 +53,16 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.SLACKERNEWS_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to the SecureBuild Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SECURE_BUILD_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.SECURE_BUILD_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image
         id: web-meta
@@ -67,7 +75,7 @@ jobs:
                 type=ref,event=branch
                 type=ref,event=tag
                 type=ref,event=pr
-          images: ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web
+          images: ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web
 
       - uses: int128/docker-build-cache-config-action@v1
         id: cache
@@ -103,15 +111,15 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ${{ env.SLACKERNEWS_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sign the web image
         id: sign-web
         run: |
-          cosign sign ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
-          echo "signature=$(cosign triangulate ${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
+          cosign sign ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
+          echo "signature=$(cosign triangulate ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 
   release:
     runs-on: ubuntu-22.04
@@ -144,7 +152,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: 'proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
       - name: Update the values.yaml with the image path

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ on:
 
 env:
   SLACKERNEWS_REGISTRY: ghcr.io
-  SECURE_BUILD_REGISTRY: ghcr.io
+  SECURE_BUILD_REGISTRY: cve0.io
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,7 +152,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$SECUREBUILD_PATH'
-          replace: 'proxy/${{ secrets.REPLICATED_APP }}/cve0.io'
+          replace: 'proxy/${{ inputs.slug }}/cve0.io'
           regex: false
 
       - id: package-helm-chart

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,7 +152,15 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
+          replace: 'proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web'
+          regex: false
+
+      - name: Update the values.yaml with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'chart/slackernews/values.yaml'
+          find: '$VERSION'
+          replace: '${{ inputs.version }}'
           regex: false
 
       - name: Update the values.yaml with the image path

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SECURE_BUILD_REGISTRY }}
-          username: ${{ github.actor }}
+          username: replicated
           password: ${{ secrets.SECURE_BUILD_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,14 @@ jobs:
           replace: 'proxy/${{ inputs.slug }}/${{ env.REGISTRY }}/${{ inputs.namespace }}/slackernews-web:${{ inputs.version }}'
           regex: false
 
+      - name: Update the values.yaml with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'chart/slackernews/values.yaml'
+          find: '$SECUREBUILD_PATH'
+          replace: 'proxy/${{ secrets.REPLICATED_APP }}/cve0.io'
+          regex: false
+
       - id: package-helm-chart
         run: |
           cd chart/slackernews && \


### PR DESCRIPTION
TL;DR
-----

Enhances the CI pipeline by adding support for proxying SecureBuild images

Details
--------

Strengthens our build by adapting it to leverage the SecureBuild registry for
the NGINX and Postgres dependencies. The modification transforms the single
registry environment variable into two distinct variables—one for SlackerNews
images and another for the SecureBuild registry—enabling the workflow to
seamlessly interact with both systems.
