### PR TITLE
Adds an SBOM to the Slackernews image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,12 +131,21 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.3.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.SLACKERNEWS_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }}
           artifact-name: sbom.spdx.json
-          github-token: ${{ github.token }}
 
       - name: Sign SBOM (keyless OIDC)
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -145,11 +145,11 @@ jobs:
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }}
-          artifact-name: sbom.spdx.json
+          output-file: sbom.spdx.json
 
       - name: Sign SBOM (keyless OIDC)
         run: |
-          cosign sign-blob --yes --output-signature sbom.spdx.json.sig sbom.spdx.json
+          cosign sign-blob --yes --output-signature sbom.spdx.json.sig sbom.spdx.json --yes
 
       - name: Attach SBOM to image in registry
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,10 +121,30 @@ jobs:
           cosign sign ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
 
-  release:
+  attest:
     runs-on: ubuntu-22.04
     needs:
       - sign
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0.16.0
+
+      - name: Generate and push SBOM as OCI artifact
+        run: |
+          syft attest ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} \
+            --oidc-issuer https://token.actions.githubusercontent.com \
+            --oidc-client-id sigstore \
+            --output spdx-json \
+            --upload
+
+  release:
+    runs-on: ubuntu-22.04
+    needs:
+      - attest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
           syft attest ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} \
             --output spdx-json --enrich javascript > sbom.spdx.json
 
-       - name: Sign SBOM (keyless OIDC)
+      - name: Sign SBOM (keyless OIDC)
         run: |
           cosign sign-blob --yes --output-signature sbom.spdx.json.sig sbom.spdx.json
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,7 +137,19 @@ jobs:
       - name: Generate and push SBOM as OCI artifact
         run: |
           syft attest ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} \
-            --output spdx-json --enrich javascript
+            --output spdx-json --enrich javascript > sbom.spdx.json
+
+       - name: Sign SBOM (keyless OIDC)
+        run: |
+          cosign sign-blob --yes --output-signature sbom.spdx.json.sig sbom.spdx.json
+
+      - name: Attach SBOM to image in registry
+        run: |
+          cosign attach sbom --sbom sbom.spdx.json ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} 
+
+      - name: Attach SBOM signature to image in registry
+        run: |
+          cosign attach sbom --sbom sbom.spdx.json.sig ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} 
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,6 +124,7 @@ jobs:
   attest:
     runs-on: ubuntu-22.04
     needs:
+      - build
       - sign
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,10 +137,7 @@ jobs:
       - name: Generate and push SBOM as OCI artifact
         run: |
           syft attest ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} \
-            --oidc-issuer https://token.actions.githubusercontent.com \
-            --oidc-client-id sigstore \
-            --output spdx-json \
-            --upload
+            --output spdx-json --enrich javascript
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,13 +131,11 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.16.0
-
-      - name: Generate and push SBOM as OCI artifact
-        run: |
-          syft attest ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} \
-            --output spdx-json --enrich javascript > sbom.spdx.json
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }}
+          artifact-name: sbom.spdx.json
 
       - name: Sign SBOM (keyless OIDC)
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,6 +136,7 @@ jobs:
         with:
           image: ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }}
           artifact-name: sbom.spdx.json
+          github-token: ${{ github.token }}
 
       - name: Sign SBOM (keyless OIDC)
         run: |


### PR DESCRIPTION
Adds SBOM generation and attestation to release workflow

TL;DR
-----

Enhances our security posture by generating, signing, and attaching Software
Bill of Materials (SBOM) to container images during the release process.

Details
--------

Introduces a new `attest` job to the release workflow that creates and signs
an SBOM for our container images. The SBOM provides a comprehensive inventory
of all components within our application, simplifying vulnerability tracking
and dependency management.

By attaching the SBOM directly to our container images in the registry,
downstream consumers can verify our software contents without additional
tooling. This approach aligns with software supply chain security best
practices and positions us for compliance with emerging security frameworks
like SLSA.

The implementation leverages Anchore's SBOM generation action to create
SPDX-formatted documents, then signs them using Cosign with keyless OIDC
authentication. Both the SBOM and its signature attach to the container image,
establishing verifiable attestations about our software composition.

We've updated the workflow dependency chain so the release job waits for
attestation completion before proceeding. This ensures our release artifacts
include these critical security enhancements.
