### PR TITLE
Works with dev (and other folks accounts)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -214,7 +214,7 @@ jobs:
         with:
           include: 'chart/slackernews/values.yaml'
           find: '$SECUREBUILD_PATH'
-          replace: 'proxy/${{ secrets.REPLICATED_APP }}/cve0.io'
+          replace: 'proxy/${{ inputs.slug }}/cve0.io'
           regex: false
 
       - id: package-helm-chart

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,6 +209,14 @@ jobs:
           replace: 'proxy/${{ inputs.slug }}/cve0.io'
           regex: false
 
+      - name: Update the values.yaml with the image path
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'chart/slackernews/values.yaml'
+          find: '$SECUREBUILD_PATH'
+          replace: 'proxy/${{ secrets.REPLICATED_APP }}/cve0.io'
+          regex: false
+
       - id: package-helm-chart
         run: |
           cd chart/slackernews && \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,11 +61,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SECURE_BUILD_REGISTRY }}
-<<<<<<< HEAD
           username: replicated
-=======
-          username: ${{ github.actor }}
->>>>>>> b0fb7a0 (Logs into SecureBuild registry)
           password: ${{ secrets.SECURE_BUILD_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image
@@ -124,7 +120,6 @@ jobs:
         run: |
           cosign sign ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
-<<<<<<< HEAD
 
   attest:
     runs-on: ubuntu-22.04
@@ -163,8 +158,6 @@ jobs:
       - name: Attach SBOM signature to image in registry
         run: |
           cosign attach sbom --sbom sbom.spdx.json.sig ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} 
-=======
->>>>>>> b0fb7a0 (Logs into SecureBuild registry)
 
   release:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,14 @@ on:
         required: true
         default: proxy.replicated.com
         type: string
+      api-endpoint:
+        description: Replicated API Endpoint
+        required: false
+        type: string
+      api-token:
+        description: Replicated API Token
+        required: false
+        type: string
 
 env:
   SLACKERNEWS_REGISTRY: ghcr.io
@@ -227,7 +235,6 @@ jobs:
             --version=${{ inputs.version }} \
             ./slackernews
 
-
       - name: Copy the helm chart to the kots directory
         run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
 
@@ -255,12 +262,27 @@ jobs:
           replace: '${{ inputs.namespace }}'
           regex: false
 
+      - name: Prepare API parameters for release action
+        id: prepare-api
+        run: |
+          if [ -z "${{ inputs.api-endpoint }}" ]; then
+            echo "api-endpoint=https://api.replicated.com/vendor" >> $GITHUB_OUTPUT
+          else
+            echo "api-endpoint=${{ inputs.api-endpoint }}" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -z "${{ inputs.api-token }}" ]; then
+            echo "api-token=${{ secrets.REPLICATED_API_TOKEN }}" >> $GITHUB_OUTPUT
+          else
+            echo "api-token=${{ inputs.api-token }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create the unstable release
         uses: replicatedhq/action-kots-release@configurable-endpoint
         with:
           replicated-app: ${{ inputs.slug }}
-          replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
-          replicated-api-origin: https://api.replicated.com/vendor
+          replicated-api-token: ${{ steps.prepare-api.outputs.api-token }}
+          replicated-api-origin: ${{ steps.prepare-api.outputs.api-endpoint }}
           yaml-dir: ./kots
           promote-channel: "Unstable"
           version: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,11 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.SECURE_BUILD_REGISTRY }}
+<<<<<<< HEAD
           username: replicated
+=======
+          username: ${{ github.actor }}
+>>>>>>> b0fb7a0 (Logs into SecureBuild registry)
           password: ${{ secrets.SECURE_BUILD_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image
@@ -120,6 +124,7 @@ jobs:
         run: |
           cosign sign ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} --yes
           echo "signature=$(cosign triangulate ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }})" >> $GITHUB_OUTPUT
+<<<<<<< HEAD
 
   attest:
     runs-on: ubuntu-22.04
@@ -158,6 +163,8 @@ jobs:
       - name: Attach SBOM signature to image in registry
         run: |
           cosign attach sbom --sbom sbom.spdx.json.sig ${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web@${{ needs.build.outputs.web-digest }} 
+=======
+>>>>>>> b0fb7a0 (Logs into SecureBuild registry)
 
   release:
     runs-on: ubuntu-22.04
@@ -263,4 +270,4 @@ jobs:
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots
           promote-channel: "Unstable"
-          version: ${{ inputs.version }}
+          ersion: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -201,7 +201,7 @@ jobs:
           replace: '${{ inputs.version }}'
           regex: false
 
-      - name: Update the values.yaml with the image path
+      - name: Update the values.yaml with the secure built image path
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'chart/slackernews/values.yaml'
@@ -263,4 +263,4 @@ jobs:
           replicated-api-origin: https://api.replicated.com/vendor
           yaml-dir: ./kots
           promote-channel: "Unstable"
-          ersion: ${{ inputs.version }}
+          version: ${{ inputs.version }}


### PR DESCRIPTION
TL;DR
-----

Enhances the release workflow with support for custom Replicated API endpoints
and tokens, enabling flexible deployment across different environments.

Details
--------

Allows teams to changing Vendor API settings when creating releases. Two new workflow inputs - `api-endpoint` and `api-token` - let you target different Replicated environments without modifying the workflow file itself.

The implementation brings several key improvements to the release process. Optional input parameters now accept custom Replicated API endpoints and tokens, while a preparation step intelligently sets sensible defaults when custom values aren't provided. The release action seamlessly uses these configurable parameters, and the workflow now supports secure build image paths in the Helm values file.

This flexibility proves particularly valuable when working with development environments or multiple Replicated teams. The workflow maintains backward compatibility by falling back to environment secrets when custom values aren't specified, ensuring existing deployments continue working while new capabilities become available.

The change also enhances Helm chart configuration by properly handling secure build paths. Container images are now correctly referenced regardless of deployment target, streamlining the deployment process across different environments.
