### PR TITLE
Standardizes releases and PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,72 @@
+<!--
+PULL REQUEST TEMPLATE
+
+This template follows a conversational, practitioner-focused style that combines technical
+precision with approachable explanations. Write as an experienced developer sharing knowledge
+with colleagues—direct and no-nonsense, but not dry or overly formal.
+
+TITLE REQUIREMENTS (ALL must pass):
+- Start with verb in third present tense (e.g., "Adds", "Fixes", "Improves")
+- ≤ 40 characters total
+- Present tense only (no "Added", "Will add", etc.)
+- No first person ("I", "We", "My")
+- Focus on INTENT (the business outcome or capability), not implementation details
+- Good: "Tracks CMX credit purchases as deals" (what it enables)
+- Bad: "Adds webhook handler and event listener" (how it's built)
+
+BODY REQUIREMENTS:
+- Use exact markdown headers below (case sensitive, correct dash count)
+- TL;DR: 1-2 sentences maximum, start with DIFFERENT verb than title. State the
+  intent (what problem gets solved or what becomes possible), not the mechanism.
+- Details: Explain WHY the change was needed and its impact. Implementation
+  details belong here, not in the title or TL;DR.
+- No forbidden phrases: "this PR", "this change", "this commit", "this update"
+- Present tense throughout
+- Technical precision: include exact versions, commands, file paths in `backticks`
+
+BEFORE SUBMITTING:
+- [ ] Title ≤ 40 characters with verb in third person present tense (quick
+  test: ends in "s")
+- [ ] TL;DR starts with different verb than title, same tense
+- [ ] No banned phrases in body
+- [ ] Headers formatted exactly as shown below
+- [ ] Tests pass: `npm test`
+- [ ] Linting passes: `npm run lint`
+-->
+
+<!-- Replace this comment with your title following the requirements above -->
+
+TL;DR
+-----
+<!-- Single sentence explaining the intent using a DIFFERENT verb than your title.
+     State what problem gets solved or what becomes possible — not how it's built.
+     Good: "Gives the revenue team automatic CRM visibility into credit purchases."
+     Bad: "Implements a webhook handler that creates deal records via the REST API."
+-->
+
+Details
+--------
+<!-- Explain WHY this change was needed and its impact. Tell the story behind the change.
+     What problem does it solve? What improvement does it enable?
+
+     Include technical details that illuminate the purpose:
+     - Specific version numbers, commands, file paths in `backticks`
+     - Link to relevant documentation or issues
+     - Mention any trade-offs or limitations honestly
+
+     Use active voice and third person present tense throughout.
+     Group related information with bullet points or numbered lists as appropriate.
+-->
+
+<!-- Optional sections you can add if relevant:
+
+## Testing
+<!-- Describe how the change was tested, any new test cases added -->
+
+## Breaking Changes
+<!-- List any breaking changes and migration steps if applicable -->
+
+## Dependencies
+<!-- Note any new dependencies or version updates -->
+
+-->

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,7 +204,7 @@ jobs:
             ./slackernews
 
       - name: Copy the helm chart to the replicated directory
-        run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
+        run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./replicated
 
       - name: Set web image in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,6 @@ on:
 
 env:
   SLACKERNEWS_REGISTRY: ghcr.io
-  SECURE_BUILD_REGISTRY: cve0.io
 
 jobs:
   build:
@@ -65,12 +64,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to the SecureBuild Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.SECURE_BUILD_REGISTRY }}
-          username: replicated
-          password: ${{ secrets.SECURE_BUILD_TOKEN }}
 
       - name: Extract metadata (tags, labels) for web image
         id: web-meta

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -186,6 +186,7 @@ jobs:
               .replicated.image.registry = "${{ inputs.proxy }}" |
               .images.slackernews.registry = "${{ inputs.proxy }}" |
               .images.slackernews.repository = "proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web" |
+              .images.slackernews.tag = "${{ inputs.version }}" |
               .images.nginx.registry = "${{ inputs.proxy }}" |
               .images.nginx.repository = "proxy/${{ inputs.slug }}/" + .images.nginx.repository |
               .images.postgres.registry = "${{ inputs.proxy }}" |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -185,45 +185,19 @@ jobs:
           version: "3.9.0"
         id: install
 
-      - name: Update the values.yaml with the registry name
-        uses: jacobtomlinson/gha-find-replace@v2
+      - name: Update the values.yaml with proxy registry
+        uses: mikefarah/yq@master
         with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$REGISTRY'
-          replace: '${{ inputs.proxy }}'
-          regex: false
-
-      - name: Update the values.yaml with the image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$IMAGE'
-          replace: 'proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web'
-          regex: false
-
-      - name: Update the values.yaml with the image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$VERSION'
-          replace: '${{ inputs.version }}'
-          regex: false
-
-      - name: Update the values.yaml with the secure built image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$SECUREBUILD_PATH'
-          replace: 'proxy/${{ inputs.slug }}/cve0.io'
-          regex: false
-
-      - name: Update the values.yaml with the image path
-        uses: jacobtomlinson/gha-find-replace@v2
-        with:
-          include: 'chart/slackernews/values.yaml'
-          find: '$SECUREBUILD_PATH'
-          replace: 'proxy/${{ inputs.slug }}/cve0.io'
-          regex: false
+          cmd: |
+            yq -i '
+              .replicated.image.registry = "${{ inputs.proxy }}" |
+              .images.slackernews.registry = "${{ inputs.proxy }}" |
+              .images.slackernews.repository = "proxy/${{ inputs.slug }}/${{ env.SLACKERNEWS_REGISTRY }}/${{ inputs.namespace }}/slackernews-web" |
+              .images.nginx.registry = "${{ inputs.proxy }}" |
+              .images.nginx.repository = "proxy/${{ inputs.slug }}/" + .images.nginx.repository |
+              .images.postgres.registry = "${{ inputs.proxy }}" |
+              .images.postgres.repository = "proxy/${{ inputs.slug }}/" + .images.postgres.repository
+            ' chart/slackernews/values.yaml
 
       - id: package-helm-chart
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,6 +251,6 @@ jobs:
           replicated-app: ${{ inputs.slug }}
           replicated-api-token: ${{ steps.prepare-api.outputs.api-token }}
           replicated-api-origin: ${{ steps.prepare-api.outputs.api-endpoint }}
-          yaml-dir: ./kots
+          yaml-dir: ./replicated
           promote-channel: "Unstable"
           version: ${{ inputs.version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,13 +203,13 @@ jobs:
             --version=${{ inputs.version }} \
             ./slackernews
 
-      - name: Copy the helm chart to the kots directory
+      - name: Copy the helm chart to the replicated directory
         run: cp ./chart/slackernews-${{ inputs.version }}.tgz ./kots
 
       - name: Set web image in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'kots/slackernews-chart.yaml'
+          include: 'replicated/slackernews-chart.yaml'
           find: '$REGISTRY'
           replace: '${{ inputs.proxy }}'
           regex: false
@@ -217,7 +217,7 @@ jobs:
       - name: Update chart version in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'kots/slackernews-chart.yaml'
+          include: 'replicated/slackernews-chart.yaml'
           find: '$VERSION'
           replace: '${{ inputs.version }}'
           regex: false
@@ -225,7 +225,7 @@ jobs:
       - name: Update chart version in HelmChart kind
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'kots/slackernews-chart.yaml'
+          include: 'replicated/slackernews-chart.yaml'
           find: '$NAMESPACE'
           replace: '${{ inputs.namespace }}'
           regex: false


### PR DESCRIPTION
TL;DR
-----
Simplifies the release workflow with structured YAML updates through `yq`, removes unused SecureBuild registry dependencies, and adds a pull request template for consistent contributions.

Details
--------
The release workflow previously used five sequential `jacobtomlinson/gha-find-replace` steps to update `chart/slackernews/values.yaml`. String-based substitution is fragile when YAML formatting changes and requires separate steps for each value. A single `mikefarah/yq@master` action now performs all structured updates—including registry, repository, and tag values—making the workflow resilient to layout changes and easier to maintain.

The SecureBuild registry (`cve0.io`) and its associated Docker login step are removed entirely. These components are no longer part of the deployment architecture, and their presence created unnecessary secret dependencies and confusion.

All `kots/` directory references in `.github/workflows/release.yaml` update to `replicated/` to match current product naming. This change covers the Helm chart copy destination, the `HelmChart` kind file paths, and the `yaml-dir` input for the Replicated GitHub action.

A pull request template is added at `.github/pull_request_template.md` to standardize future contributions. The template enforces concise titles, clear intent statements, and consistent formatting for better reviewability.

## Testing
Workflow changes were verified by reviewing the `yq` command syntax against `chart/slackernews/values.yaml` structure. The command correctly updates `.replicated.image.registry`, `.images.slackernews.registry`, `.images.slackernews.repository`, `.images.slackernews.tag`, `.images.nginx.registry`, `.images.nginx.repository`, `.images.postgres.registry`, and `.images.postgres.repository`.

## Dependencies
- Adds `mikefarah/yq@master` for structured YAML manipulation in GitHub Actions
- Removes dependency on `jacobtomlinson/gha-find-replace` for `values.yaml` updates