### PR TITLE
Customizes embedded cluster domain URLs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,11 @@ on:
         required: true
         default: proxy.replicated.com
         type: string
+      app-service:
+        description: Replicated App Service
+        required: true
+        default: replicated.app
+        type: string
       api-endpoint:
         description: Replicated API Endpoint
         required: false
@@ -229,6 +234,15 @@ jobs:
           find: '$NAMESPACE'
           replace: '${{ inputs.namespace }}'
           regex: false
+
+      - name: Update the embedded-cluster.yaml custom domains
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            yq -i '
+              .spec.domains.proxyRegistryDomain = "${{ inputs.proxy }}" |
+              .spec.domains.replicatedAppDomain = "${{ inputs.app-service }}"
+            ' replicated/embedded-cluster.yaml
 
       - name: Prepare API parameters for release action
         id: prepare-api

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.worktrees
+
 branding/email-templates.json
 branding/email-templates/node_modules
 branding/email-templates/dist


### PR DESCRIPTION
TL;DR
-----
Enables full domain control for embedded cluster releases.

Details
--------
The release workflow previously supports customizing the proxy registry domain via workflow input but leaves the Replicated app service domain hardcoded in `replicated/embedded-cluster.yaml`. That mismatch causes custom deployments to reference an incorrect app service endpoint.

The workflow now injects both `proxyRegistryDomain` and `replicatedAppDomain` into `.spec.domains` in `replicated/embedded-cluster.yaml` using `yq`. A new `app-service` input parameter accepts the app service domain, defaulting to `replicated.app`.

Also adds `.worktrees` to `.gitignore` to keep git worktree directories out of the repository.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenCode](https://img.shields.io/badge/OpenCode-kimi--k2p6-000000?logo=openai&logoColor=white)